### PR TITLE
Added botpress installation in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ npm install botpress-platform-webchat
 ```bash
 yarn add botpress-platform-webchat
 ```
+### Using Botpress
+
+```bash
+botpress install botpress-platform-webchat
+```
 
 ## How to use it
 


### PR DESCRIPTION
Botpress native UI doesn't has option to add `botpress-platform-webchat`. It took me quite some time to figure out how to use it via Embedded Website code.