### PR TITLE
fix chat rendering in dev/x

### DIFF
--- a/src/views/index.jsx
+++ b/src/views/index.jsx
@@ -12,6 +12,31 @@ import UMMComponent from './UMM'
 import style from './style.scss'
 
 export default class UMMModule extends React.Component {
+  constructor(props) {
+    super()
+    this.session = new ChatSession({ events: props.bp.events })
+  }
+
+  render() {
+    const className = classnames(style.chatComponent, 'bp-modules-chat')
+    return (
+      <div>
+        <h3>There is nothing to see here, yet.</h3>
+        <p>
+          This module currently serves to show the Chat Emulator you see at the bottom of your screen. Uninstall this
+          module to get rid of it.
+        </p>
+        <p>
+          This module is a work in progress, it will also allow you to embed a chat window to your bot on any website
+          (no ETA yet, please contact us on Slack).
+        </p>
+      </div>
+    )
+  }
+}
+
+export class Embedded extends React.Component {
+  // Deprecated
 
   constructor(props) {
     super()
@@ -20,33 +45,16 @@ export default class UMMModule extends React.Component {
 
   render() {
     const className = classnames(style.chatComponent, 'bp-modules-chat')
-    return <div>
-      <h3>There is nothing to see here, yet.</h3>
-      <p>This module currently serves to show the Chat Emulator you see at the bottom of your screen. 
-      Uninstall this module to get rid of it.</p>
-      <p>This module is a work in progress, it will also allow you to embed a chat window to your bot on any website (no ETA yet, please contact us on Slack).</p>
-    </div>
+    return (
+      <div className={style.embedded}>
+        <Chat className={className} session={this.session} />
+      </div>
+    )
   }
 }
 
-export class Embedded extends React.Component { // Deprecated
-
-  constructor(props) {
-    super()
-    this.session = new ChatSession({ events: props.bp.events })
-  }
-
-  render() {
-    const className = classnames(style.chatComponent, 'bp-modules-chat')
-    return <div className={style.embedded}>
-      <Chat
-        className={className}
-        session={this.session} />
-    </div>
-  }
-}
-
-export class Emulator extends React.Component { // Deprecated
+export class Emulator extends React.Component {
+  // Deprecated
 
   constructor(props) {
     super()
@@ -56,8 +64,8 @@ export class Emulator extends React.Component { // Deprecated
       collapsed: false
     }
   }
-  
-  toggleCollapsed() {
+
+  toggleCollapsed = () => {
     if (!this.state.collapsed) {
       const originalHeight = this.resizable.state.height
       const originalWidth = this.resizable.state.width
@@ -69,20 +77,17 @@ export class Emulator extends React.Component { // Deprecated
     }
   }
 
-  startNewSession(event) {
+  startNewSession = event => {
     event.preventDefault()
     event.stopPropagation()
-    
+
     this.session.startNewSession()
   }
 
   componentDidMount() {
     const className = classnames(style.chatComponent, 'bp-modules-chat')
 
-    const chatComponent = <Chat
-      showWelcome={true}
-      className={className}
-      session={this.session} />
+    const chatComponent = <Chat showWelcome={true} className={className} session={this.session} />
 
     this.setState({ chatComponent })
   }
@@ -95,88 +100,91 @@ export class Emulator extends React.Component { // Deprecated
       [style.hidden]: this.state.collapsed
     })
 
-    return <div className={emulatorStyle}>
-      <Resizable
-        ref={c => { this.resizable = c }}
-        width={300}
-        height={400}
-        minWidth={300}
-        minHeight={minHeight}
-        maxHeight={maxheight}
-        enable={{
-          top: true,
-          right: true,
-          topLeft: true,
-          left: true,
-          topRight: true,
-          bottom: false, // Disable bottom because sticks in bottom left corner
-          bottomRight: false,
-          bottomLeft: false
-        }}>
-        <div className={style.header} onClick={::this.toggleCollapsed}>
-          <div className={style.left}>Emulator</div>
-          <div className={style.right}>
-            <span className={style.button} onClick={::this.startNewSession}>
-              <i className="icon material-icons">refresh</i>
-            </span>
+    return (
+      <div className={emulatorStyle}>
+        <Resizable
+          ref={c => {
+            this.resizable = c
+          }}
+          width={300}
+          height={400}
+          minWidth={300}
+          minHeight={minHeight}
+          maxHeight={maxheight}
+          enable={{
+            top: true,
+            right: true,
+            topLeft: true,
+            left: true,
+            topRight: true,
+            bottom: false, // Disable bottom because sticks in bottom left corner
+            bottomRight: false,
+            bottomLeft: false
+          }}
+        >
+          <div className={style.header} onClick={this.toggleCollapsed}>
+            <div className={style.left}>Emulator</div>
+            <div className={style.right}>
+              <span className={style.button} onClick={this.startNewSession}>
+                <i className="icon material-icons">refresh</i>
+              </span>
+            </div>
           </div>
-        </div>
-        {this.state.chatComponent}
-      </Resizable>
-    </div>
+          {this.state.chatComponent}
+        </Resizable>
+      </div>
+    )
   }
 }
 
-export class Web extends React.Component {
-  constructor(props) {
-    super(props)
-  }
+export const Web = WebComponent
 
-  render() {
-    return <WebComponent />
-  }
-}
+export const UMMOutgoing = UMMComponent
 
-export class UMMOutgoing extends React.Component {
-  constructor(props) {
-    super()
-  }
-
-  render() {
-    return <UMMComponent {...this.props} />
-  }
-}
+const INJECTION_ID = 'botpress-platform-webchat-injection'
+const INJECTION_URL = '/api/botpress-platform-webchat/inject.js'
 
 export class WebInjection extends React.Component {
-  render () {
+  // TODO: is it used?
+  componentWillMount() {
     var node = window.document.createElement('script')
-    node.src = '/api/botpress-platform-webchat/inject.js'
+    node.src = INJECTION_URL
     window.document.body.appendChild(node)
+  }
+
+  render() {
+    return null
   }
 }
 
 export class WebBotpressUIInjection extends React.Component {
-  render () {
-    if (document.querySelector('#botpress-platform-webchat-injection')) return null;
+  componentWillMount() {
+    if (document.getElementById(INJECTION_ID)) return
 
-    var node = window.document.createElement('script')
-    node.src = '/api/botpress-platform-webchat/inject.js'
-    node.id = 'botpress-platform-webchat-injection'
+    const node = window.document.createElement('script')
+    node.src = INJECTION_URL
+    node.id = INJECTION_ID
     node.dataset.optionsJson = JSON.stringify({ hideWidget: true })
 
     window.document.body.appendChild(node)
 
-    let button = document.createElement('li')
-    const buttonOptions = {
+    const button = document.createElement('li')
+    Object.assign(button, {
       role: 'presentation',
       onclick: () => botpressChat('show'),
-      innerHTML: `<a role="button" href="#">
-                    <span class="bp-full-screen">
-                      <span class="glyphicon glyphicon-comment"></span>
-                    </span>
-                  </a>`
-    }
-    Object.keys(buttonOptions).forEach(key => button[key] = buttonOptions[key])
+      innerHTML: `
+        <a role="button" href="#">
+          <span class="bp-full-screen">
+            <span class="glyphicon glyphicon-comment"></span>
+          </span>
+        </a>
+      `
+    })
+
     document.querySelector('.nav.navbar-nav').appendChild(button)
+  }
+
+  render() {
+    return null
   }
 }


### PR DESCRIPTION
Many changes were automatically done by my prettier plugin.

The important changes are:
1) switching from `render` to `componentWillMount`
2) similar switching in the `WebInjection` component - is it ever used? Can we just kill it maybe? 
3) I've simplified the `Web` and `UMMOutgoing` because they looked like trivial aliases though `UMMOutgoing` wasn't passing the props down to `super` which I don't know if it was important
4) Demonstrated how the binding syntax `::` can be replaced with fat arrow instance methods - just because I was already at this, and this binding syntax is breaking my editor's syntax highlighting
