### PR TITLE
Fix reading botName, botAvatarUrl config props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botpress-platform-webchat",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "An embeddable web chat for Botpress bots",
   "main": "bin/node.bundle.js",
   "homepage": "https://github.com/botpress/botpress-platform-webchat",

--- a/src/socket.js
+++ b/src/socket.js
@@ -11,7 +11,7 @@ module.exports = async (bp, config) => {
   const { appendBotMessage, getOrCreateRecentConversation } = db(knex, bp.botfile)
   const { getOrCreateUser } = await users(bp, config)
 
-  const { bot_name = 'Bot', bot_avatar = null } = config || {}
+  const { botName = 'Bot', botAvatarUrl = null } = config || {}
 
   bp.middlewares.register({
     name: 'webchat.sendMessages',
@@ -53,7 +53,7 @@ module.exports = async (bp, config) => {
       await Promise.delay(typing)
     }
 
-    const message = await appendBotMessage(bot_name, bot_avatar, conversationId, event)
+    const message = await appendBotMessage(botName, botAvatarUrl, conversationId, event)
 
     Object.assign(message, {
       __room: 'visitor:' + socketId // This is used to send to the relevant user's socket


### PR DESCRIPTION
Two config props were incorrectly read from the config object, in one place.

This fixes so any configured `botName` is used correctly above the bot's messages in the chat.

(Also fixed prop name for `botAvatarUrl`.)