### PR TITLE
Testing Modules with PeerDependancy

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
   "dependencies": {
     "aws-sdk": "^2.108.0",
     "axios": "^0.16.2",
-    "botpress": "^1.1.10",
     "date-fns": "^1.28.5",
     "lodash": "^4.17.4",
     "mime": "^2.0.3",
@@ -79,5 +78,8 @@
     "serve-static": "^1.12.3",
     "sillyname": "^0.1.0",
     "uuid": "^3.1.0"
+  },
+  "optionalDependencies": {
+    "botpress": "^1.1.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   "dependencies": {
     "aws-sdk": "^2.108.0",
     "axios": "^0.16.2",
+    "botpress": "^1.1.10",
     "date-fns": "^1.28.5",
     "lodash": "^4.17.4",
     "mime": "^2.0.3",


### PR DESCRIPTION
Hi @slvnperron,

I got problem went I install `botpress-platform-webchat` for testing in a project.

Went I do `yarn link botpress-platform-webchat` in me project (Testing purpose).

I got this Error

![](https://screenshots.firefoxusercontent.com/images/29835241-8a0c-414a-8dcf-f3500af57a48.png)

I Investigated a little bit and I found that Botpress module did not install because he was in peer dependency. 

So I suggested adding Botpress in an optimal Depencancy. By doing this, Botpress will be installed in devMode. 

And you can also ignore-optional dependancy with this command

`yarn install --ignore-optional`

What do you things?

- [] Kept in Optional dependency 
- [] Or put it into devDependancy  

